### PR TITLE
NXC-186: Update GitHub Actions workflow for release process

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,6 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      packages: write
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
@@ -42,7 +45,7 @@ jobs:
       run: dotnet restore
     - name: Determine Version
       id: version
-      run: echo "::set-output name=version::${GITHUB_REF/refs\/tags\//}"
+      run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Package and Deploy
       if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
       env:


### PR DESCRIPTION
This pull request makes minor improvements to the `.github/workflows/dotnet.yml` GitHub Actions workflow, primarily focusing on permissions and compatibility with updated GitHub Actions syntax.

* Added explicit `permissions` for the publish job, granting `write` access to `packages` and `read` access to `contents` to comply with best practices for GitHub Actions workflows.
* Updated the `Determine Version` step to use the modern `$GITHUB_OUTPUT` syntax instead of the deprecated `::set-output` command for setting outputs.